### PR TITLE
Add OWNERS and OWNERS_ALIASES files for Prow setup

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- mattmoor
+- n3wscott
+- vaikas
+- lionelvillard
+- nachocano
+
+reviewers:
+- lberk

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+aliases:
+  productivity-approvers:
+  - adrcunha
+  - chaodaiG
+  productivity-reviewers:
+  - adrcunha
+  - chaodaiG
+  - coryrc
+  - chizhg
+  - steuhs
+  - yt3liu
+


### PR DESCRIPTION
The [Prow Setup Docs](https://github.com/knative/test-infra/blob/master/ci/prow_setup.md#setting-up-prow-for-a-new-repo-reviewers-assignment-and-auto-merge) suggest that the OWNERS file needs to already be setup before we can add the prow config.

@nachocano @lionelvillard @n3wscott 